### PR TITLE
Tweaks to icd_morb_flag, create_markdown

### DIFF
--- a/R/create_markdown.R
+++ b/R/create_markdown.R
@@ -42,7 +42,7 @@ create_markdown <- function(file_name = "report",
   }
 
   # Aid user in selecting where to create this template
-  directory <- tcltk::tk_choose.dir(default = getwd(), caption = "Select a folder to create the QMD template")
+  directory <- rstudioapi::selectDirectory(caption = "Select a folder to create the QMD template")
 
   if (is.na(directory) || directory == "") {
     stop("No directory selected. Template creation cancelled.")

--- a/doc/icd_morb_flag.Rmd
+++ b/doc/icd_morb_flag.Rmd
@@ -37,11 +37,12 @@ library(WAACHShelp)
     + Some sort of ID variable.
     + Some sort of dob variable.
   + The DOB variable can be called whatever we like. As a default, it is called "dob", after the date of birth variable in the DOBmap files.
+  + Other variables can be carried across from DOBmap file. These can be specified in `dobmap_other_vars`.
   
 
 The ID variable of the DOBmap file must be called the same thing as in the `data` file. This is the variable that the joining is based on.
 
-By default, we assume the `rootnum` variable exists in both data sets. It does not matter what this variable is called in reality---the `joining_var` argument can be specified to any string.
+By default, we assume the `rootnum` variable exists in both data sets. It does not matter what this variable is called in reality---the `id_var` argument can be specified to any string.
 
 # Flagging
 
@@ -205,7 +206,7 @@ TRUE/FALSE argument on whether to collapse records to a person level, instead of
 The summary works such that if *any* record for an individual is flagged "yes", then the collapsed record for that individual is "yes".
 Otherwise, if *all* records for an individual are flagged "no", then the collapsed record for that individual is "no".
 
-The number of rows in the flagged data set when `person_summary = TRUE` correspond to the number of unique values of the `joining_var` (e.g., rootnum, NEWUID).
+The number of rows in the flagged data set when `person_summary = TRUE` correspond to the number of unique values of the `id_var` (e.g., rootnum, NEWUID).
 
 ```{r eval = F, echo = T}
 icd_morb_flag(data = morb_dat, 

--- a/doc/icd_morb_flag.html
+++ b/doc/icd_morb_flag.html
@@ -374,6 +374,8 @@ does not matter what these flagging variables are called.</li>
 </ul></li>
 <li>The DOB variable can be called whatever we like. As a default, it is
 called “dob”, after the date of birth variable in the DOBmap files.</li>
+<li>Other variables can be carried across from DOBmap file. These can be
+specified in <code>dobmap_other_vars</code>.</li>
 </ul></li>
 </ul>
 <p>The ID variable of the DOBmap file must be called the same thing as
@@ -381,7 +383,7 @@ in the <code>data</code> file. This is the variable that the joining is
 based on.</p>
 <p>By default, we assume the <code>rootnum</code> variable exists in
 both data sets. It does not matter what this variable is called in
-reality—the <code>joining_var</code> argument can be specified to any
+reality—the <code>id_var</code> argument can be specified to any
 string.</p>
 </div>
 <div id="flagging" class="section level1">
@@ -564,7 +566,7 @@ is flagged “yes”, then the collapsed record for that individual is
 “no”, then the collapsed record for that individual is “no”.</p>
 <p>The number of rows in the flagged data set when
 <code>person_summary = TRUE</code> correspond to the number of unique
-values of the <code>joining_var</code> (e.g., rootnum, NEWUID).</p>
+values of the <code>id_var</code> (e.g., rootnum, NEWUID).</p>
 <div class="sourceCode" id="cb8"><pre class="sourceCode r"><code class="sourceCode r"><span id="cb8-1"><a href="#cb8-1" tabindex="-1"></a><span class="fu">icd_morb_flag</span>(<span class="at">data =</span> morb_dat, </span>
 <span id="cb8-2"><a href="#cb8-2" tabindex="-1"></a>              <span class="at">flag_category =</span> <span class="st">&quot;MH_morb&quot;</span>,</span>
 <span id="cb8-3"><a href="#cb8-3" tabindex="-1"></a>              <span class="at">person_summary =</span> <span class="cn">TRUE</span>)</span></code></pre></div>

--- a/man/icd_morb_flag.Rd
+++ b/man/icd_morb_flag.Rd
@@ -15,15 +15,16 @@ icd_morb_flag(
   under_age = FALSE,
   age = 18,
   person_summary = FALSE,
-  joining_var = "rootnum",
-  dob_var = "dob",
-  morb_date_var = "subadm"
+  id_var = "rootnum",
+  morb_date_var = "subadm",
+  dobmap_dob_var = "dob",
+  dobmap_other_vars = NULL
 )
 }
 \arguments{
 \item{data}{Input dataset (morbidity).}
 
-\item{dobmap}{DOBMap file corresponding to input dataset.}
+\item{dobmap}{DOBmap file corresponding to input dataset.}
 
 \item{flag_category}{Type of flag to generate. Takes values from reference file (e.g., MH_morb, Sub_morb, etc.) or "Other" for custom ICD specification and flagging.}
 
@@ -35,17 +36,19 @@ icd_morb_flag(
 
 \item{diag_type_custom_params}{Search parameters to search across when \code{diag_type == "custom"}. Must be a list where the keys are the variable names and values are the inputs to \code{WAACHShelp::val_filt}. Can also be a list of lists where multiple ICD can be searched across for a single variable. See examples for specification.}
 
-\item{under_age}{Return additional variables corresponding to when participant was strictly under \code{age} y.o.. Uses DOBMap DOB and subadm morbidity admission date. Variables have suffix "_under{age}".}
+\item{under_age}{Return additional variables corresponding to when participant was strictly under \code{age} y.o.. Uses DOBmap DOB and subadm morbidity admission date. Variables have suffix "_under{age}".}
 
 \item{age}{Integer. Age to consider for the \code{under_age} variable (default 18).}
 
 \item{person_summary}{Summarise results at a person-level.}
 
-\item{joining_var}{Joining (ID) variable consistent between \code{data} and \code{dobmap}. Default \code{rootnum}.}
-
-\item{dob_var}{Date of birth (DOB) variable in \code{dobmap}. Default \code{"dob"}.}
+\item{id_var}{Joining (ID) variable consistent between \code{data} and \code{dobmap}. Default \code{rootnum}.}
 
 \item{morb_date_var}{Hospital morbidity date variable in \code{data}. Default \code{"subadm"}.}
+
+\item{dobmap_dob_var}{Date of birth (DOB) variable in \code{dobmap}. Default \code{"dob"}.}
+
+\item{dobmap_other_vars}{Other variables to carry across from DOBmap file when joining to \code{data}. Default \code{NULL}. Can be a vector of strings.}
 }
 \value{
 Flagged dataframe.
@@ -67,7 +70,8 @@ icd_morb_flag(data = morb,
               dobmap = dob,
               flag_category = "MH_morb", # Create any MH contact flag
               under_age = T, # Return additional set of flags depending on whether participant is under 18 at time of admission.
-              age = 18
+              age = 18,
+              dobmap_other_vars = c("xyz123", "abc456") # Also select variables `xyz123`, `abc456` from DOBmap and join onto `data` file.
               )
 
 # Example 2: Basic use

--- a/vignettes/icd_morb_flag.Rmd
+++ b/vignettes/icd_morb_flag.Rmd
@@ -37,11 +37,12 @@ library(WAACHShelp)
     + Some sort of ID variable.
     + Some sort of dob variable.
   + The DOB variable can be called whatever we like. As a default, it is called "dob", after the date of birth variable in the DOBmap files.
+  + Other variables can be carried across from DOBmap file. These can be specified in `dobmap_other_vars`.
   
 
 The ID variable of the DOBmap file must be called the same thing as in the `data` file. This is the variable that the joining is based on.
 
-By default, we assume the `rootnum` variable exists in both data sets. It does not matter what this variable is called in reality---the `joining_var` argument can be specified to any string.
+By default, we assume the `rootnum` variable exists in both data sets. It does not matter what this variable is called in reality---the `id_var` argument can be specified to any string.
 
 # Flagging
 
@@ -205,7 +206,7 @@ TRUE/FALSE argument on whether to collapse records to a person level, instead of
 The summary works such that if *any* record for an individual is flagged "yes", then the collapsed record for that individual is "yes".
 Otherwise, if *all* records for an individual are flagged "no", then the collapsed record for that individual is "no".
 
-The number of rows in the flagged data set when `person_summary = TRUE` correspond to the number of unique values of the `joining_var` (e.g., rootnum, NEWUID).
+The number of rows in the flagged data set when `person_summary = TRUE` correspond to the number of unique values of the `id_var` (e.g., rootnum, NEWUID).
 
 ```{r eval = F, echo = T}
 icd_morb_flag(data = morb_dat, 


### PR DESCRIPTION
Minor adjustments to icd_morb_flag

1) create_markdown: Use rstudioapi::selectDirectory
2) icd_morb_flag: Add `dobmap_other_vars` functionality to select and bring across other variables from DOBmap into joined/flagged morbidity file.

Small change to create_markdown