### PR TITLE
Additional warning message for icd_morb_flag for non-unique DOBMAP IDs

### DIFF
--- a/R/icd_morb_flag.R
+++ b/R/icd_morb_flag.R
@@ -189,15 +189,11 @@ icd_morb_flag <- function(data,
   }
 
   # Warning if dobmap is not unique
-  if (under_age == TRUE & !is.null(dobmap)){
-    dobmap_rows <- dobmap %>%
-      dplyr::group_by(!!rlang::sym(id_var)) %>%
-      dplyr::summarise(n_records = dplyr::n()) %>%
-      dplyr::ungroup() %>%
-      dplyr::filter(n_records > 1) %>%
-      nrow()
-
-    if (dobmap_rows > 0){
+  if (under_age == TRUE & !is.null(dobmap)) {
+    if (dobmap %>%
+        dplyr::count(!!rlang::sym(id_var)) %>%
+        dplyr::filter(n > 1) %>%
+        nrow() > 0) {
       warning(sprintf("`dobmap` is not uniquely defined. Multiple records exist per `%s`.\nOutput may have more rows than input data set.", id_var), call. = FALSE)
     }
   }

--- a/R/icd_morb_flag.R
+++ b/R/icd_morb_flag.R
@@ -190,10 +190,7 @@ icd_morb_flag <- function(data,
 
   # Warning if dobmap is not unique
   if (under_age == TRUE & !is.null(dobmap)) {
-    if (dobmap %>%
-        dplyr::count(!!rlang::sym(id_var)) %>%
-        dplyr::filter(n > 1) %>%
-        nrow() > 0) {
+    if ((any(duplicated(dobmap[[id_var]])))) {
       warning(sprintf("`dobmap` is not uniquely defined. Multiple records exist per `%s`.\nOutput may have more rows than input data set.", id_var), call. = FALSE)
     }
   }

--- a/R/icd_morb_flag.R
+++ b/R/icd_morb_flag.R
@@ -188,6 +188,20 @@ icd_morb_flag <- function(data,
                  dobmap_dob_var))
   }
 
+  # Warning if dobmap is not unique
+  if (under_age == TRUE & !is.null(dobmap)){
+    dobmap_rows <- dobmap %>%
+      dplyr::group_by(!!rlang::sym(id_var)) %>%
+      dplyr::summarise(n_records = dplyr::n()) %>%
+      dplyr::ungroup() %>%
+      dplyr::filter(n_records > 1) %>%
+      nrow()
+
+    if (dobmap_rows > 0){
+      warning(sprintf("`dobmap` is not uniquely defined. Multiple records exist per `%s`.\nOutput may have more rows than input data set.", id_var), call. = FALSE)
+    }
+  }
+
   # Error if `morb_date_var` is not in the data
   if (under_age == TRUE & !morb_date_var %in% colnames(data)) {
     stop(sprintf("Error: `data` does not contain a column named '%s'. Consider changing the `morb_date_var` argument, if necessary.",


### PR DESCRIPTION
Warning message if there are multiple rows per `id_var` in the specified DOBmap file. Does not necessarily pose a problem (depending on the use case), but worth flagging regardless.